### PR TITLE
Switch basic example to a higher port number

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,12 +212,12 @@ python basic.py
 And visit:
 
 ```
-curl http://localhost:711/swagger/spec
+curl http://localhost:7111/swagger/spec
 ```
 
 access to web
 ```
-http://localhost:711/swagger/spec.html
+http://localhost:7111/swagger/spec.html
 ```
 
 # Passing more metadata to swagger

--- a/example/basic.py
+++ b/example/basic.py
@@ -211,5 +211,5 @@ def make_app():
 
 if __name__ == "__main__":
     app = make_app()
-    app.listen(711)
+    app.listen(7111)
     tornado.ioloop.IOLoop.current().start()


### PR DESCRIPTION
So linux users won't need escalated privileges just to try it out.

Suggested [hopefully] trivial fix for https://github.com/SerenaFeng/tornado-swagger/issues/2